### PR TITLE
refactor(cli): clean up CLI options help texts and synchronize READMEDev

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,11 @@ Usage: KEGGaNOG [OPTIONS]
 │                                       files.                                 │
 │ --overwrite  -overwrite               Overwrite the output directory if it   │
 │                                       already exists.                        │
-│ --dpi        -dpi            INTEGER  DPI for the output image (default:     │
-│                                       300).                                  │
+│ --dpi        -dpi            INTEGER  DPI for the output image.              │
 │                                       [default: 300]                         │
-│ --color      -c              TEXT     Cmap for seaborn heatmap (default:     │
-│                                       Blues).                                │
+│ --color      -c              TEXT     Cmap for seaborn heatmap.              │
 │                                       [default: Blues]                       │
-│ --name       -n              TEXT     Sample name for labeling (default:     │
-│                                       SAMPLE).                               │
+│ --name       -n              TEXT     Sample name for labeling.              │
 │                                       [default: SAMPLE]                      │
 │ --group      -g                       Group the heatmap based on predefined  │
 │                                       categories.                            │

--- a/kegganog/kegganog.py
+++ b/kegganog/kegganog.py
@@ -138,19 +138,19 @@ def main(
         300,
         "-dpi",
         "--dpi",
-        help="DPI for the output image (default: 300).",
+        help="DPI for the output image.",
     ),
     color: str = typer.Option(
         "Blues",
         "-c",
         "--color",
-        help="Cmap for seaborn heatmap (default: Blues).",
+        help="Cmap for seaborn heatmap.",
     ),
     sample_name: str = typer.Option(
         "SAMPLE",
         "-n",
         "--name",
-        help="Sample name for labeling (default: SAMPLE).",
+        help="Sample name for labeling.",
     ),
     group: bool = typer.Option(
         False,


### PR DESCRIPTION
### Summary
This PR cleans up the CLI help messages by removing redundant, hardcoded `(default: ...)` strings from `typer.Option` definitions. Since Typer automatically appends default values to the help output, this prevents duplication in the terminal interface. 

The `README.md` usage section has been synchronized accordingly to match the cleaner auto-generated format.

### Changes
* **`kegganog/kegganog.py`**: Removed hardcoded defaults from `--dpi`, `--color`, and `--name` options.
* **`README.md`**: Updated the CLI usage block to reflect the new standardized formatting `[default: value]`.

### Verification
* Ran `kegganog --help` to ensure no duplicate default values are printed.