### PR TITLE
refactor: show help when calling main command without arguments

### DIFF
--- a/kegganog/kegganog.py
+++ b/kegganog/kegganog.py
@@ -108,6 +108,7 @@ def _run_pipeline(params: CLIParams) -> None:
 
 @app.command(
     help="KEGGaNOG: Link eggNOG-mapper and KEGG-Decoder for pathway visualization.",
+    no_args_is_help=True,
 )
 def main(
     input_path: Optional[str] = typer.Option(


### PR DESCRIPTION
### Description
Improved CLI usability by setting `no_args_is_help=True` for the main command. Now, when the user runs the application without arguments, the help menu is displayed automatically instead of showing an error or doing nothing.
### Changes
Added `no_args_is_help=True` to the `@app.command()` decorator in `main()`.